### PR TITLE
更新至0.1.4

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,6 +2,7 @@ appId: com.noteby.app
 productName: note-by
 directories:
   buildResources: build
+publish: null
 files:
   - '!**/.vscode/*'
   - '!src/*'

--- a/package-lock.json
+++ b/package-lock.json
@@ -614,39 +614,39 @@
       }
     },
     "node_modules/@douyinfe/semi-animation": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-animation/-/semi-animation-2.83.0.tgz",
-      "integrity": "sha512-NXA5WvYU7wpp4bGI3Mwzy/flwK3isJpmVc6Y/nUtRoTsFqXlJFA0ItWVQXjZEC4dOH50Y0vJkSn0vtF4JWB4CQ==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-animation/-/semi-animation-2.84.0.tgz",
+      "integrity": "sha512-SHQiU+JIOEoL1McR8bCuT0+nNxQpXRLtxxforPQJZBuYekVordSaO8uAku+02SUh7xg+x3dDFKv44QiM6fB3rw==",
       "license": "MIT",
       "dependencies": {
         "bezier-easing": "^2.1.0"
       }
     },
     "node_modules/@douyinfe/semi-animation-react": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-animation-react/-/semi-animation-react-2.83.0.tgz",
-      "integrity": "sha512-p3oVM9fBh+oJ4MBB7OArF7HSYRnicxO7GUtvjxJI2AoSHVpzjS0buVkWaeNbSDq0onUI/+um8pUKZlbGwgxKkg==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-animation-react/-/semi-animation-react-2.84.0.tgz",
+      "integrity": "sha512-jw57LwjWMER5OIapC3yFRkxcsGUwIJcIuBdfymHVdqEm2HBfw+4u8RTC+l41xxJ9YQDTyicTw8ZF1s0Fs0Zhew==",
       "license": "MIT",
       "dependencies": {
-        "@douyinfe/semi-animation": "2.83.0",
-        "@douyinfe/semi-animation-styled": "2.83.0",
+        "@douyinfe/semi-animation": "2.84.0",
+        "@douyinfe/semi-animation-styled": "2.84.0",
         "classnames": "^2.2.6"
       }
     },
     "node_modules/@douyinfe/semi-animation-styled": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.83.0.tgz",
-      "integrity": "sha512-gQkcoyRJal3mWb9bXuC1z8v1a9qwVGsiZXjOJVcb1gl4GAD0jrS0dnInKmdXtLF6dEodty9DWGRgqMBVZHwVzA==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.84.0.tgz",
+      "integrity": "sha512-KqiCAlXEWZdOuae5ljiK6CqTqzCh6WKq+rOncodfvAqeabbZ1S3u0UHT2Jf0hUnD6OVRn4vf8aYerw+j2AZb9w==",
       "license": "MIT"
     },
     "node_modules/@douyinfe/semi-foundation": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-foundation/-/semi-foundation-2.83.0.tgz",
-      "integrity": "sha512-rkHOafQrSGR4jCsDH97mioAkVu6d6Y2/lAmLMpKhD3Zah0Hh1fDbO6JyrhTmNx1Af7J5GuVbR4q9qoAcy8/1jg==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-foundation/-/semi-foundation-2.84.0.tgz",
+      "integrity": "sha512-SoxXCeRbaRMjCvbs8zwhng9vKyE3EgR8W2VZ9+0t4ME9EK8N8mUff0Du7u30IymjfmR3OdpNEh34uW8/cgobqg==",
       "license": "MIT",
       "dependencies": {
-        "@douyinfe/semi-animation": "2.83.0",
-        "@douyinfe/semi-json-viewer-core": "2.83.0",
+        "@douyinfe/semi-animation": "2.84.0",
+        "@douyinfe/semi-json-viewer-core": "2.84.0",
         "@mdx-js/mdx": "^3.0.1",
         "async-validator": "^3.5.0",
         "classnames": "^2.2.6",
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@douyinfe/semi-icons": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-icons/-/semi-icons-2.83.0.tgz",
-      "integrity": "sha512-zWC1uwjJwHT/YTVIQ46O35WU6hi+T+Q1Sk6otgjc7fKymQR4BKDAkG9lOSttN5LmzljBUlQqbNym2NwahtQfwA==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-icons/-/semi-icons-2.84.0.tgz",
+      "integrity": "sha512-EShiV2TgviUvhRB7vBAewO7C+75p9s/9BlRA5G9c/TXBkdyzU4U4hN+d7pY5ScVS6H4+rf2Gu/RMnXRH5dKhSg==",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.6"
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@douyinfe/semi-icons-lab": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-icons-lab/-/semi-icons-lab-2.83.0.tgz",
-      "integrity": "sha512-KEUjVup2HDf/X3gIGEnSWuCoexoW/R65XWyBjbL9d+/cSkKc51Qv0NpGDsllBemM5aJxpbMcrGH0V2VwBHTYVQ==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-icons-lab/-/semi-icons-lab-2.84.0.tgz",
+      "integrity": "sha512-CmTgDoJnjc032P7l/NKjMuEoj/GsD41rvJWuNCkJODgm/MCLc8ks8s0xVowBsSG15OLHCa1Rm5F1wbvOROOMzg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -684,44 +684,44 @@
       }
     },
     "node_modules/@douyinfe/semi-illustrations": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.83.0.tgz",
-      "integrity": "sha512-hgK1wuCXAncSEVdBg8EtdItI5Mck+nZPUe+eLt51oSQjZbkxa3x/pGFM3FYVKvxbMuOMy9gJqF0JgLg32WG+Eg==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.84.0.tgz",
+      "integrity": "sha512-t6CLMHTvR3N5c27U3i3iYHiUbJb4i96E6N3++w1VCGielPly9mM5WHvQdHc9mbfjM7lMfjsvo1LGbUyxO+BQ8g==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.0.0"
       }
     },
     "node_modules/@douyinfe/semi-json-viewer-core": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-json-viewer-core/-/semi-json-viewer-core-2.83.0.tgz",
-      "integrity": "sha512-hqDDsmpu/FUiRm3OVDEzbW3w4akHjbsRqBUHdGlpLGMha5xB0BV00JR1c4iI5UBkIIi6xT3zCCeNeBTBaDpnSQ==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-json-viewer-core/-/semi-json-viewer-core-2.84.0.tgz",
+      "integrity": "sha512-de6eDd7mkNPx7B/qxYP+OqkfFxZax21b1X5vnqjg0Tg2cuzbWPzaO3sBuZ5JR1I91hzyuxQzdjBbF5H4ij6ctA==",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"
       }
     },
     "node_modules/@douyinfe/semi-theme-default": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.83.0.tgz",
-      "integrity": "sha512-596NETp57+6YyN4Lc3t3a2k7dlx/uqCZhN+c3X5xsgZES6E5QsdKDXvEMsEa8QCTZbvVWIdtDOtdvqgFqaRMgQ==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.84.0.tgz",
+      "integrity": "sha512-tQBS3aolqvYju+1MlJb3lMuv/muy8vvoLFNWsi7tkzR/cyYOSBNkFpJJU4zoF1BJjhjn4zYrsuxgUHAxlMBCSw==",
       "license": "MIT"
     },
     "node_modules/@douyinfe/semi-ui": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-ui/-/semi-ui-2.83.0.tgz",
-      "integrity": "sha512-Obz2AipjoT870qgLwK89NHIeMlEBj2+c6wH0Mpp2Vef9XUNZcNraLlG5dLPbRfFos3XXFHN+lOTKgumK9kT6aA==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmmirror.com/@douyinfe/semi-ui/-/semi-ui-2.84.0.tgz",
+      "integrity": "sha512-c3siUgqmW58gwpI1pVTrP4fhM1MII+kVewnygASxLrIt8QNqCQQpWJhWuibKrCDINiyETamZhtD+Qsn6H19WuQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@douyinfe/semi-animation": "2.83.0",
-        "@douyinfe/semi-animation-react": "2.83.0",
-        "@douyinfe/semi-foundation": "2.83.0",
-        "@douyinfe/semi-icons": "2.83.0",
-        "@douyinfe/semi-illustrations": "2.83.0",
-        "@douyinfe/semi-theme-default": "2.83.0",
+        "@douyinfe/semi-animation": "2.84.0",
+        "@douyinfe/semi-animation-react": "2.84.0",
+        "@douyinfe/semi-foundation": "2.84.0",
+        "@douyinfe/semi-icons": "2.84.0",
+        "@douyinfe/semi-illustrations": "2.84.0",
+        "@douyinfe/semi-theme-default": "2.84.0",
         "async-validator": "^3.5.0",
         "classnames": "^2.2.6",
         "copy-text-to-clipboard": "^2.1.1",
@@ -1907,9 +1907,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmmirror.com/@eslint/js/-/js-9.31.0.tgz",
-      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmmirror.com/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1944,21 +1944,21 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmmirror.com/@floating-ui/core/-/core-1.7.2.tgz",
-      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmmirror.com/@floating-ui/dom/-/dom-1.7.2.tgz",
-      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
       }
     },
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@lancedb/lancedb": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb/-/lancedb-0.21.1.tgz",
-      "integrity": "sha512-lXjfJDEeKgecF1rifdShjzyDk3VUrPr6TCqNZ+VqJu2SYGtt5DFb8b6zXJtWyB4wF2kHCzYy2z1BujKYpitrKQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb/-/lancedb-0.21.2.tgz",
+      "integrity": "sha512-3RPsGbdhFbwgy7GisQnlgf+5r6R73N4xIkPNISJfvratJ5kVoQIuswra/jJxAf8N5tKriD9UnrQyUsRbmblwFQ==",
       "cpu": [
         "x64",
         "arm64"
@@ -2132,23 +2132,23 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@lancedb/lancedb-darwin-arm64": "0.21.1",
-        "@lancedb/lancedb-darwin-x64": "0.21.1",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.21.1",
-        "@lancedb/lancedb-linux-arm64-musl": "0.21.1",
-        "@lancedb/lancedb-linux-x64-gnu": "0.21.1",
-        "@lancedb/lancedb-linux-x64-musl": "0.21.1",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.21.1",
-        "@lancedb/lancedb-win32-x64-msvc": "0.21.1"
+        "@lancedb/lancedb-darwin-arm64": "0.21.2",
+        "@lancedb/lancedb-darwin-x64": "0.21.2",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.21.2",
+        "@lancedb/lancedb-linux-arm64-musl": "0.21.2",
+        "@lancedb/lancedb-linux-x64-gnu": "0.21.2",
+        "@lancedb/lancedb-linux-x64-musl": "0.21.2",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.21.2",
+        "@lancedb/lancedb-win32-x64-msvc": "0.21.2"
       },
       "peerDependencies": {
         "apache-arrow": ">=15.0.0 <=18.1.0"
       }
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.21.1.tgz",
-      "integrity": "sha512-qv4JvOtZtbwUdRAtfqZq8ni/uhRr2xIynFtZu7oNTgGCBDnQLpaElAxglpkkQbzzTUA81TZ0ZVZNnb3+AnKQ3g==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.21.2.tgz",
+      "integrity": "sha512-aCRc/Jrpll7AMQejK18HzNmYtEzV+oU0zTSFhYJTu1SqDTA+CoXoibj9SmXHYwY6MYlfx5y6kI8UkjtU3T8zHQ==",
       "cpu": [
         "arm64"
       ],
@@ -2162,9 +2162,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-darwin-x64": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.21.1.tgz",
-      "integrity": "sha512-4FPI+Cd6MJqoMhMXhN4AthwRX57Y0bkYXfFPHzM633R2spL7gDF9Zgf6Q+ObpVlH8WrORzQZETuy7yTQba41hQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.21.2.tgz",
+      "integrity": "sha512-Oiiz1W9E2VwKpmPCrRF+40Hd6M1kj/ej6FNQwXaCy688+CJC0dKlz95omQU3B2WnynDiwszUyNVknyMwNI3sCQ==",
       "cpu": [
         "x64"
       ],
@@ -2178,9 +2178,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.21.1.tgz",
-      "integrity": "sha512-pOWRvDX11XC5NX1LL7RnLxKT0k2IHpJ4KsY6ZDWn3cV4ilQcS9CEd66DWN4mJCKjitT7gW3L8YPkefD7F7RoOg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.21.2.tgz",
+      "integrity": "sha512-LyLlEYUDlpm2sSMzoqmVWIYbY6U5AVZhpZucX0L6a3usyuce6V/Z9UGR6Uw9284xZKsPFnYNRlLZwwUGkb2tKw==",
       "cpu": [
         "arm64"
       ],
@@ -2194,9 +2194,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-musl": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.21.1.tgz",
-      "integrity": "sha512-skPt+3EZqc3uMMy+7Zl66MLo38mi9YLQh3ydbSyRRQDh/3HO3BJhta54LllLVIW64rSLr7ksh4jTob8IOE5wXA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.21.2.tgz",
+      "integrity": "sha512-J7fK1gzBrrBx+CnUk+BnvU3V/A+F7EfqveOw2SUbTP7Gy5bXdUL2sieVVuJlRmmhfvjLTAGxsITr2RkO9n3wZw==",
       "cpu": [
         "arm64"
       ],
@@ -2210,9 +2210,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-gnu": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.21.1.tgz",
-      "integrity": "sha512-iKP1lYtBZO58PH2N6WtQ2sDtKEzOqyCmgx1J+/etx09n93B7OIkXQv9HBhdIQJ20ZTXvDVvjuKHyN996EUV63A==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.21.2.tgz",
+      "integrity": "sha512-yD1lWUe/gLR4QFA3ZdWc2ukdgbfXDcRoi9iTgqedUwAj++Wld64wOFjYhZbYwzGNClXlkJJiP70jzhomBv3RIw==",
       "cpu": [
         "x64"
       ],
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-musl": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.21.1.tgz",
-      "integrity": "sha512-G9UUaYTPpeKBtYq/MoZwViBQ0u20X1XTaxvHUlnZp8eE+QowqMx+qY0AXsPiPRo4MNl7cih0LvIcNersDdB/yQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.21.2.tgz",
+      "integrity": "sha512-Dq3G6KtGlxidS3mY4cebp7GHRT7rQoe6wpXTzlCankANvEOwxBI68wxid3+GDcqi4jkGHrOrHTQVZqIKZ2NXnQ==",
       "cpu": [
         "x64"
       ],
@@ -2242,9 +2242,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.21.1.tgz",
-      "integrity": "sha512-nNWh2dZEHYGQnJKjpRXqP1qyrqjTyPpF5PONbaFiPNHH3mm9mXgOHfLo8aPG6ACkw9pmlhmM4DX8F48KHJLGPQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.21.2.tgz",
+      "integrity": "sha512-cPxzm5G2LhiA+DjVGueEnc7K909gzH6q+UGeNXF5Ly4IsvE6BRrjSQNmTRBGflD/aQEV7VD4SqiIj/rpmIZ4Sg==",
       "cpu": [
         "arm64"
       ],
@@ -2258,9 +2258,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-x64-msvc": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.21.1.tgz",
-      "integrity": "sha512-JBuPzI8S+g6aAiORQYGRffBLjvkpbHUUmas/gJ3Phatm9AicVk1YUYBxCifuW7AZifrKKca8qp4NKSFTCCY1uw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.21.2.tgz",
+      "integrity": "sha512-jewJB5ggDi4jlZocmmjMnwQYDHHr+t0jhiZQINRs/I4tkt9RxaRVPPz7D4rP+NXILj4PgKfDqKcDVeJ/5bc4hQ==",
       "cpu": [
         "x64"
       ],
@@ -2561,9 +2561,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
       "cpu": [
         "arm"
       ],
@@ -2575,9 +2575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
       "cpu": [
         "arm64"
       ],
@@ -2589,9 +2589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
+      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
       "cpu": [
         "arm64"
       ],
@@ -2603,9 +2603,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
       "cpu": [
         "x64"
       ],
@@ -2617,9 +2617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
       "cpu": [
         "arm64"
       ],
@@ -2631,9 +2631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
       "cpu": [
         "x64"
       ],
@@ -2645,9 +2645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
       "cpu": [
         "arm"
       ],
@@ -2659,9 +2659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
       "cpu": [
         "arm"
       ],
@@ -2673,9 +2673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
       "cpu": [
         "arm64"
       ],
@@ -2687,9 +2687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
       "cpu": [
         "arm64"
       ],
@@ -2701,9 +2701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
       "cpu": [
         "loong64"
       ],
@@ -2714,10 +2714,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
       "cpu": [
         "ppc64"
       ],
@@ -2729,9 +2729,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2743,9 +2743,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
       "cpu": [
         "riscv64"
       ],
@@ -2757,9 +2757,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
       "cpu": [
         "s390x"
       ],
@@ -2771,9 +2771,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
       "cpu": [
         "x64"
       ],
@@ -2785,9 +2785,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
       "cpu": [
         "x64"
       ],
@@ -2799,9 +2799,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
       "cpu": [
         "arm64"
       ],
@@ -2813,9 +2813,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
       "cpu": [
         "ia32"
       ],
@@ -2827,9 +2827,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
       "cpu": [
         "x64"
       ],
@@ -2887,48 +2887,48 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/core/-/core-3.0.7.tgz",
-      "integrity": "sha512-/NC0BbekWzi5sC+s7gRrGIv33cUfuiZUG5DWx8TNedA6b6aTFPHUe+2wKRPaPQ0pfGdOWU0nsOkboUJ9dAjl4g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/core/-/core-3.0.9.tgz",
+      "integrity": "sha512-1zdDyILerBcD3P0fu8kCtPLOFj0R5utjexCQ2CZ46pckn/Wk4V+WUBARzhG5Yz2JDkmJIUIcmLBVrL6G1rjJWg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-blockquote/-/extension-blockquote-3.0.7.tgz",
-      "integrity": "sha512-bYJ7r4hYcBZ7GI0LSV0Oxb9rmy/qb0idAf/osvflG2r1tf5CsiW5NYAqlOYAsIVA2OCwXELDlRGCgeKBQ26Kyw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-blockquote/-/extension-blockquote-3.0.9.tgz",
+      "integrity": "sha512-dGhMWb6GIjgIUuLQDhSlHT6yB4YvnYqe01nHzEvcbSii75KOcLwboVnqxw4p+gsDZLvZRGv/6bZBJh7GKZa8OQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bold/-/extension-bold-3.0.7.tgz",
-      "integrity": "sha512-CQG07yvrIsScLe5NplAuCkVh0sd97Udv1clAGbqfzeV8YfzpV3M7J/Vb09pWyovx3SjDqfsZpkr3RemeKEPY9Q==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bold/-/extension-bold-3.0.9.tgz",
+      "integrity": "sha512-rVULIFt9ZO+fO5ty9zuC3HwY3knxUw7q9JBztpKPfQQCuIJ+iQnOfB8NtI3L8hxVSxhIR1pqr8B3S/8vlpXbVg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.0.7.tgz",
-      "integrity": "sha512-/oL5kgOHm1AJtyLC6v1+txk/RI9WvI4/gDQ6oWukmT7aQHIfqvCW0DN/ahmX9nxGFAIRlbrooVxLn5Y6/P0adQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.0.9.tgz",
+      "integrity": "sha512-fZQfdSbKJl3J+Yi+s8NrcLBgXHOaGVD4g+vn+orTPUlZdG9FWvEoon8DexOdK9OvYnW6QMM7kS8whOgpogVyUQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -2938,110 +2938,110 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bullet-list/-/extension-bullet-list-3.0.7.tgz",
-      "integrity": "sha512-9gPc3Tw2Bw7qKLbyW0s05YntE77127pOXQXcclB4I3MXAuz/K03f+DGuSRhOq9K2Oo86BPHdL5I9Ap9cmuS0Tg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bullet-list/-/extension-bullet-list-3.0.9.tgz",
+      "integrity": "sha512-Aob5TVfrtoEzfTm3wl7lognmWia6EEilOxLihSGISCvI4FTndJg+mwhumduQeYCLWkF9i/DR87m2/3EbjR3R4Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.0.7"
+        "@tiptap/extension-list": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-character-count": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-character-count/-/extension-character-count-3.0.7.tgz",
-      "integrity": "sha512-Ip3qmWADJBVNInGRMNUyx9oDG9U//Qjr57/rI0VwTKotwn2vXSYxRdKGPEm7KvwUlNONCtv/7vTXO6FprkU0Yw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-character-count/-/extension-character-count-3.0.9.tgz",
+      "integrity": "sha512-KKtHfvMlYCNszldPvmzDzvRSV/Xukb7T/t4IMPgFp2LUDPuBK1z4TPP8HEsONTFAAKc+JgnJPPkMxfhh/tFbnQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.0.7"
+        "@tiptap/extensions": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code/-/extension-code-3.0.7.tgz",
-      "integrity": "sha512-6wdUqtXbnIuyKR7xteF2UCnsW2dLNtBKxWvAiOweA7L41HYvburh/tjbkffkNc5KP2XsKzdGbygpunwJMPj6+A==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code/-/extension-code-3.0.9.tgz",
+      "integrity": "sha512-jMo7crwLIefwy13WI2FzxlyJN9AbLNsESFbJuv/KPzjpN7uzPKYsE33Uy2IZD5hPoHtA5UmAUfbz0HzWtWy5Yw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block/-/extension-code-block-3.0.7.tgz",
-      "integrity": "sha512-WifMv7N1G1Fnd2oZ+g80FjBpV/eI/fxHKCK3hw03l8LoWgeFaU/6LC93qTV6idkfia3YwiA6WnuyOqlI0FSZ9A==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block/-/extension-code-block-3.0.9.tgz",
+      "integrity": "sha512-H692k9sHIE3rR3S+BIknQXsLb8HSojk+7gQ5DV0hYajSzpJ02OUL4AnNlpMuSgZuaq+ljpN4sT8kCIzIE1kQxw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-code-block-lowlight": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block-lowlight/-/extension-code-block-lowlight-3.0.7.tgz",
-      "integrity": "sha512-y1sHjzxpYqIKikdT5y5ajCOw4hDIPGjPpIBP7x7iw7jyt8a/w/bI8ozUk4epLBpgOvvAwmdIqi7eV7ORMvQaGQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block-lowlight/-/extension-code-block-lowlight-3.0.9.tgz",
+      "integrity": "sha512-J5REgsah4yCaiWwy6FOygbv5FlHw28xzqxdIqm3922uq+l2LKwCAF4EwR3u19ZLGgtH2Wy27BClR97JZPLvVCQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/extension-code-block": "^3.0.7",
-        "@tiptap/pm": "^3.0.7",
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/extension-code-block": "^3.0.9",
+        "@tiptap/pm": "^3.0.9",
         "highlight.js": "^11",
         "lowlight": "^2 || ^3"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-document/-/extension-document-3.0.7.tgz",
-      "integrity": "sha512-HJg1nPPZ9fv5oEMwpONeIfT0FjTrgNGuGAat/hgcBi/R2GUNir2/PM/3d6y8QtkR/EgkgcFakCc9azySXLmyUQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-document/-/extension-document-3.0.9.tgz",
+      "integrity": "sha512-DB/R5e6QvuGhY8EhCkfNjR2xQfz/TOWoxfQGhDuy5U+oK3WBwCcHq9t5+nbSCMHtKfi/i49aHKDvv7TQCpuP0w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-dropcursor/-/extension-dropcursor-3.0.7.tgz",
-      "integrity": "sha512-0i2XWdRgYbj6PEPC+pMcGiF/hwg0jl+MavPt1733qWzoDqMEls9cEBTQ9S4HS0TI/jbN/kNavTQ5LlI33kWrww==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-dropcursor/-/extension-dropcursor-3.0.9.tgz",
+      "integrity": "sha512-+P+1nfeCtPLj3OHNiATOL3UyM2omZ8+ac6MKm+FxunRAZZsHzbEFUYYdLF7prEmaf0z0c1k4LKSWpbrIX92pKA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.0.7"
+        "@tiptap/extensions": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-floating-menu/-/extension-floating-menu-3.0.7.tgz",
-      "integrity": "sha512-JJv9pV8EwTcGe2w/1hMhjAhfmvoCh8ha3Rh/9soWfe8FfwRnQQC6ykqmYWuAx1HDoS+sNYPNUbyDxIwgnbIc+w==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-floating-menu/-/extension-floating-menu-3.0.9.tgz",
+      "integrity": "sha512-WYQ3mW6G0zxoni6TegpQ46a1Qe1zj8Ev5sBH79H4Mbf0qsc7MOq07jLjipv9M0EJJPUi0cfkQlwfV41nH1ue/g==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -3050,334 +3050,334 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-gapcursor/-/extension-gapcursor-3.0.7.tgz",
-      "integrity": "sha512-F4ERd5r59WHbY0ALBbrJ/2z9dl+7VSmsMV/ZkzTgq0TZV9KKz3SsCFcCdIZEYzRCEp69/yYtkTofN10xIa+J6A==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-gapcursor/-/extension-gapcursor-3.0.9.tgz",
+      "integrity": "sha512-+jy7Z/V6nOtvWin+zJYYoRwEYDOHDlF34Ey1T7A8aRcJlPeAQhoB1Ek7R3Rd3nsuByz70IfQapDvkbhY1nkNvQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.0.7"
+        "@tiptap/extensions": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-hard-break/-/extension-hard-break-3.0.7.tgz",
-      "integrity": "sha512-OWrFrKp9PDs9nKJRmyPX22YoscqmoW25VZYeUfvNcAYtI84xYz871s1JmLZkpxqOyI9TafUADFiaRISDnX5EcA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-hard-break/-/extension-hard-break-3.0.9.tgz",
+      "integrity": "sha512-PWNYsUwVsMWt/R5/OWjfGb+7DQT0DvH+1owBimRq0pWZepg8qkz1jdPGgsRmUFyERRsXeEpgj3VaQfrgbyUfrA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-heading/-/extension-heading-3.0.7.tgz",
-      "integrity": "sha512-uS7fFcilFuzKEvhUgndELqlGweD+nZeLOb6oqUE5hM49vECjM7qVjVQnlhV+MH2W1w8eD08cn1lu6lDxaMOe5w==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-heading/-/extension-heading-3.0.9.tgz",
+      "integrity": "sha512-LRLCIt87fvDZ5CdkinzhkCwRz5ax6FlsjJzG32MJ3wXyvVslqeLXBvH28JFUZEyzgcd/SnYmYxnef5+yvAX61g==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-highlight": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-highlight/-/extension-highlight-3.0.7.tgz",
-      "integrity": "sha512-3oIRuXAg7l9+VPIMwHycXcqtZ7XJcC5vnLhPAQXIesYun6L9EoXmQox0225z8jpPG70N8zfl+YSd4qjsTMPaAg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-highlight/-/extension-highlight-3.0.9.tgz",
+      "integrity": "sha512-22cCRUMRCLYiGMw1boLGygAghtMs/QjC7Y4HLfwFurJ4d8S8FDD1YU6Iz6mzINIfhqEvke2u+9Wi3AydM/SIow==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.0.7.tgz",
-      "integrity": "sha512-m0r4tzfVX3r0ZD7uvDf/GAiVr7lJjYwhZHC+M+JMhYXVI6eB9OXXzhdOIsw9W5QcmhCBaqU+VuPKUusTn4TKLg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.0.9.tgz",
+      "integrity": "sha512-jPNCOte0y9R3Y4PiEA/CRGgRk8WoL700Mnn8NPVHa4juUjvMl1qxL8hdnW/k8cxhrBA8tV0qcq82+/Vqq6jSfA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-image/-/extension-image-3.0.7.tgz",
-      "integrity": "sha512-hs6TiSmefwvAqxwhy4+ZFCbmAXiAeWq4v5Zd65kQ7dvN7epeV0NM7ME5su/oscQgoKvNAy1r/4sJVaTnHomYMQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-image/-/extension-image-3.0.9.tgz",
+      "integrity": "sha512-/2igN/oIF58zqX5fcg00bf6qGLcQyXHysl5I8GiurkvO95d+SQTlYbJneSRUpt6CgrUKbhRnMBPVubmapgg+Zw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-italic/-/extension-italic-3.0.7.tgz",
-      "integrity": "sha512-L05cehSOd7iZWI/igPb90TgQ6RKk2UuuYdatmXff3QUJpYPYct6abcrMb+CeFKJqE9vaXy46dCQkOuPW+bFwkA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-italic/-/extension-italic-3.0.9.tgz",
+      "integrity": "sha512-Gt4FbMtZerzKpit8+FvIjIQ3CBD559/FFC+kOT9y8JHlINeqWyh/bgHuaA/9/XtHphOQiA7NDwOiuPh4KIKpqA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-link/-/extension-link-3.0.7.tgz",
-      "integrity": "sha512-e53MddBSVKpxxQ2JmHfyZQ2VBLwqlZxqwn0DQHFMXyCKTzpdUC0DOtkvrY7OVz6HA3yz29qR+qquQxIxcDPrfg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-link/-/extension-link-3.0.9.tgz",
+      "integrity": "sha512-cOsG3vpct7/JuenxCePDj5dlaSUEe2eK/g/jlRixgW4Llx5DvG2yj8+gha4MHdCUp/MrUBR4M+NJk1dOOSKXGw==",
       "license": "MIT",
       "dependencies": {
-        "linkifyjs": "^4.2.0"
+        "linkifyjs": "^4.3.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list/-/extension-list-3.0.7.tgz",
-      "integrity": "sha512-rwu5dXRO0YLyxndMHI17PoxK0x0ZaMZKRZflqOy8fSnXNwd3Tdy8/6a9tsmpgO38kOZEYuvMVaeB7J/+UeBVLg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list/-/extension-list-3.0.9.tgz",
+      "integrity": "sha512-y5JQoFmVR+6FhDdEz2oFIMkURSRSDhCtsrlNWdUpSTGnTAa2WZT7nEhHcIMSGvYU3t0fkfLQ9yTMSaQZFa5GLA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-item/-/extension-list-item-3.0.7.tgz",
-      "integrity": "sha512-QfW+dtukl5v6oOA1n4wtAYev5yY78nqc2O8jHGZD18xhqNVerh2xBVIH9wOGHPz4q5Em2Ju7xbqXYl0vg2De+w==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-item/-/extension-list-item-3.0.9.tgz",
+      "integrity": "sha512-K+ogk1BH/eYhsK9nSTXNdIXlxQcXzty6h1QFiZNr9XmaLk+q4NZFHR5FVz3EJ7QXyw+Gv/2FQn+T2Q/GpbMxZQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.0.7"
+        "@tiptap/extension-list": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-keymap/-/extension-list-keymap-3.0.7.tgz",
-      "integrity": "sha512-KJWXsyHU8E6SGmlZMHNjSg+XrkmCncJT2l5QGEjTUjlhqwulu+4psTDRio9tCdtepiasTL7qEekGWAhz9wEgzQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-keymap/-/extension-list-keymap-3.0.9.tgz",
+      "integrity": "sha512-naz4+EFzLN695f53GATiglPOc5SOLBm1DNhhUHZNlrUVfDtKmrdbo8t9a/NhAE6Ne/pfg5tbuS+OKuvbJaJcAg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.0.7"
+        "@tiptap/extension-list": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-ordered-list/-/extension-ordered-list-3.0.7.tgz",
-      "integrity": "sha512-F/cbG0vt1cjkoJ4A65E6vpZQizZwnE4gJHKAw3ymDdCoZKYaO4OV1UTo98W/jgryORy/HLO12+hogsRvgRvK9Q==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-ordered-list/-/extension-ordered-list-3.0.9.tgz",
+      "integrity": "sha512-ACubdGc/y/rKPEgHTO7hDSg547wRRA+Es7c/rQgjrkpI///LBJQfixyUvNg2UNNPttNsavF/CUwhshCeo9MeBA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.0.7"
+        "@tiptap/extension-list": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-paragraph/-/extension-paragraph-3.0.7.tgz",
-      "integrity": "sha512-1lp+/CbYmm1ZnR6CNlreUIWCNQk0cBzLVgS5R8SKfVyYaXo11qQq6Yq8URLhpuge4yXkPGMhClwCLzJ9D9R+eg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-paragraph/-/extension-paragraph-3.0.9.tgz",
+      "integrity": "sha512-K5zGg4zLxxqAG0BgtRpLvKclYSGoSSuU1Fza0M5MwUgrFA0S2q4JnLB1czQ77S4pfb3hpScIe50fwJzZmIUEQw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-placeholder": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-placeholder/-/extension-placeholder-3.0.7.tgz",
-      "integrity": "sha512-f4oV4/ZNtOE1mbnJMzsBO1PmmbB9kfW4kEujDvDitn3YSWXfr5EW83vVwriaFnc4FY6RTId3wgsAV7U3tSYHyA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-placeholder/-/extension-placeholder-3.0.9.tgz",
+      "integrity": "sha512-OgDVijDrNFDJpe/1/yMx6VFEmGBt0vE6ZWw5kGkM4NVfOxhRvv6mSZXio269dc9oBSjmyTISKaI1JAYVCfyJIw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.0.7"
+        "@tiptap/extensions": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-strike/-/extension-strike-3.0.7.tgz",
-      "integrity": "sha512-WUCd5CMgS6pg0ZGKXsaxVrnEvO/h6XUehebL0yggAsRKSoGERInR2iLfhU4p1f4zk0cD3ydNLJdqZu0H/MIABw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-strike/-/extension-strike-3.0.9.tgz",
+      "integrity": "sha512-2TBQ9P/FGe+/34ckfwP+eCdb4vbxDVZ5qD0piDIR9Ws5QI5IdtW90pNO4roxiPeRdVFrhTbFPEIuL0tg4NQRmg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table/-/extension-table-3.0.7.tgz",
-      "integrity": "sha512-S4tvIgagzWnvXLHfltXucgS9TlBwPcQTjQR4llbxmKHAQM4+e77+NGcXXDcQ7E1TdAp3Tk8xRGerGIP7kjCFRA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table/-/extension-table-3.0.9.tgz",
+      "integrity": "sha512-jygDvj9MIwMlzs2c+4MZwXCXI6sc7LcKgPFoJ93qiCn6CZrDwaX3XzxXi0VAg7MexsUi1nVaGZQk/gv+Pf3rKw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-table-cell": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table-cell/-/extension-table-cell-3.0.7.tgz",
-      "integrity": "sha512-UuEBL4YbNiKHi31vkj3g96hIzDwgdBlREQNkz+hazXUG4CizR6o7YVNJX4w/00pO3kSXOokMjvcN7LURMYlbAw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table-cell/-/extension-table-cell-3.0.9.tgz",
+      "integrity": "sha512-3prTFcDCBdZJD+nzkFWFejbEVMbfuNI73GPce+Pk3hLy4cSXFnF0QKjdG8oBoAWULMIsE4FPyY3enQJ4brI6ew==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-table": "^3.0.7"
+        "@tiptap/extension-table": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-table-header": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table-header/-/extension-table-header-3.0.7.tgz",
-      "integrity": "sha512-jGg5G9NYrCboCVbKDva9+75BS5vNpDXDYDT0QKKKL6wOBTLTY7nHJ1XTG0uK7OdTRM8byCLLLLkL7NkMLDWW5A==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table-header/-/extension-table-header-3.0.9.tgz",
+      "integrity": "sha512-yPLDzw1EHM6MtuqQIMTmI1ZOAg7ReY09CdYLGtMbSdcLvrg1afg/oOc7K5qSt5qOcLYHW8TJlyykjfhz/qoQtg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-table": "^3.0.7"
+        "@tiptap/extension-table": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-table-row": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table-row/-/extension-table-row-3.0.7.tgz",
-      "integrity": "sha512-nd7pWLo89RO+sBv6aL+URwirHfqukFFHSUNpz0+xZY5T2HyG279fjCUUZjSu6Sb6Dosq1CYhHr22Xh8GmgbEiw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-table-row/-/extension-table-row-3.0.9.tgz",
+      "integrity": "sha512-BfaKJqYGjWa5TjGRjNZzbYwaExp29VV1WlJsR7SjdQ74DhY70/cth1Jt70LHSpTfJeclwbYwGOGVdXZqTwUtWA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-table": "^3.0.7"
+        "@tiptap/extension-table": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text/-/extension-text-3.0.7.tgz",
-      "integrity": "sha512-yf5dNcPLB5SbQ0cQq8qyjiMj9khx4Y4EJoyrDSAok/9zYM3ULqwTPkTSZ2eW6VX/grJeyBVleeBHk1PjJ7NiVw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text/-/extension-text-3.0.9.tgz",
+      "integrity": "sha512-yWdz4aW1nu5YGcinxfu3FXiwMnP/7jp+s7dFXhq9m/6zhDUD2+qyUwhJfIU4Tcz+BGdVHqoNgOA3QXLMA6jyFA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text-align/-/extension-text-align-3.0.7.tgz",
-      "integrity": "sha512-3XywI2+dvb5IIO5NnZqyoXrRnikGyCIN7wWymTI7eqD213Ovs19/sfbW5kXLPsBYiNBb12nbG6pmPhr21mPvoA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text-align/-/extension-text-align-3.0.9.tgz",
+      "integrity": "sha512-QQBk8orIdntL3tPzGkKIqEogqArvO/x4dfvbAA2K0DqvS9uGJ3Qp4X6Twv+BIHLjeyhZl/z48vEMB+bjwvqg+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text-style/-/extension-text-style-3.0.7.tgz",
-      "integrity": "sha512-naJ1XxlbFJ1qlpA+i54lQYKuhWP1dnkUslM86OT0TZt0zJBeu7LIrqSOVGmMB++lF/btnQLMnYkYSSnkLgIw3A==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text-style/-/extension-text-style-3.0.9.tgz",
+      "integrity": "sha512-x7SZLS537c7w789n8re0IktmkBZqz98dux/hwpFAcC4oL06YPjFG7Dy9mAiKcsKqKWI0eAyTQvMybz+TJusBbw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-underline/-/extension-underline-3.0.7.tgz",
-      "integrity": "sha512-pw2v5kbkovaWaC1G2IxP7g94vmUMlRBzZlCnLEyfFxtGa9LVAsUFlFFWaYJEmq7ZPG/tblWCnFfEZuQqFVd8Sg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-underline/-/extension-underline-3.0.9.tgz",
+      "integrity": "sha512-xLR5NbnxlEJmvfb4Aj8wCbTmh/ycnPsSDeP8+TAsdAYxypSA6BP6G0t4d4NWreqAq+tq6QV6Eh0+YDN0G1VZxw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7"
+        "@tiptap/core": "^3.0.9"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extensions/-/extensions-3.0.7.tgz",
-      "integrity": "sha512-GkXX5l7Q/543BKsC14j8M3qT+75ILb7138zy7cZoHm/s1ztV1XTknpEswBZIRZA9n6qq+Wd9g5qkbR879s6xhA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extensions/-/extensions-3.0.9.tgz",
+      "integrity": "sha512-IyTcPnZXUf0nxDkC+CCWh10vzn81Kq50euV/ivk8IyPr15hxPiT3Zk1LmCI10Pqf4Bwgz38XUIWtToDfIeEgpg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/pm/-/pm-3.0.7.tgz",
-      "integrity": "sha512-f8PnWjYqbMCxny8cyjbFNeIyeOYLECTa/7gj8DJr53Ns+P94b4kYIt/GkveR5KoOxsbmXi8Uc4mjcR1giQPaIQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/pm/-/pm-3.0.9.tgz",
+      "integrity": "sha512-cJdnpGyirRxwi6M4IkyapEK/jhcjFXdfX3uhJp/4uVH1dynNXalV0gE/YnH/yt55kzwvG9OUrwOQt+t1iXgNog==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -3405,9 +3405,9 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/react/-/react-3.0.7.tgz",
-      "integrity": "sha512-d7uq4KHi52DsN4dRYY5p1ei+uaAq0h+xUUOW9JxPspe2/xM88ZmvKBZIYlqyWix0CGx7BRNmCDLcP6toOmW/MQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/react/-/react-3.0.9.tgz",
+      "integrity": "sha512-BbvWPSgYGvd9m8fPXKI81gf9KP+1SMCPpscbtbbhPyxiW2ziY+jwo+i7MwVI73P89hWAJCy/43UnOde438HmOA==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -3419,46 +3419,46 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.0.7",
-        "@tiptap/extension-floating-menu": "^3.0.7"
+        "@tiptap/extension-bubble-menu": "^3.0.9",
+        "@tiptap/extension-floating-menu": "^3.0.9"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7",
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/starter-kit/-/starter-kit-3.0.7.tgz",
-      "integrity": "sha512-oTHZp6GXQQaZfZi8Fh7klH2YUeGq73XPF35CFw41mwdWdUUUms3ipaCKFqUyEYO21JMf3pZylJLxUucx5U7isg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/starter-kit/-/starter-kit-3.0.9.tgz",
+      "integrity": "sha512-CYg6tV5fYOvkP1gyATkJJj+nFYmwjDKLipQc/r0D/tHKypxefENrm4G7mf4B78zsB/izfk5mW3iujvyeod6EcQ==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/extension-blockquote": "^3.0.7",
-        "@tiptap/extension-bold": "^3.0.7",
-        "@tiptap/extension-bullet-list": "^3.0.7",
-        "@tiptap/extension-code": "^3.0.7",
-        "@tiptap/extension-code-block": "^3.0.7",
-        "@tiptap/extension-document": "^3.0.7",
-        "@tiptap/extension-dropcursor": "^3.0.7",
-        "@tiptap/extension-gapcursor": "^3.0.7",
-        "@tiptap/extension-hard-break": "^3.0.7",
-        "@tiptap/extension-heading": "^3.0.7",
-        "@tiptap/extension-horizontal-rule": "^3.0.7",
-        "@tiptap/extension-italic": "^3.0.7",
-        "@tiptap/extension-link": "^3.0.7",
-        "@tiptap/extension-list": "^3.0.7",
-        "@tiptap/extension-list-item": "^3.0.7",
-        "@tiptap/extension-list-keymap": "^3.0.7",
-        "@tiptap/extension-ordered-list": "^3.0.7",
-        "@tiptap/extension-paragraph": "^3.0.7",
-        "@tiptap/extension-strike": "^3.0.7",
-        "@tiptap/extension-text": "^3.0.7",
-        "@tiptap/extension-underline": "^3.0.7",
-        "@tiptap/extensions": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/extension-blockquote": "^3.0.9",
+        "@tiptap/extension-bold": "^3.0.9",
+        "@tiptap/extension-bullet-list": "^3.0.9",
+        "@tiptap/extension-code": "^3.0.9",
+        "@tiptap/extension-code-block": "^3.0.9",
+        "@tiptap/extension-document": "^3.0.9",
+        "@tiptap/extension-dropcursor": "^3.0.9",
+        "@tiptap/extension-gapcursor": "^3.0.9",
+        "@tiptap/extension-hard-break": "^3.0.9",
+        "@tiptap/extension-heading": "^3.0.9",
+        "@tiptap/extension-horizontal-rule": "^3.0.9",
+        "@tiptap/extension-italic": "^3.0.9",
+        "@tiptap/extension-link": "^3.0.9",
+        "@tiptap/extension-list": "^3.0.9",
+        "@tiptap/extension-list-item": "^3.0.9",
+        "@tiptap/extension-list-keymap": "^3.0.9",
+        "@tiptap/extension-ordered-list": "^3.0.9",
+        "@tiptap/extension-paragraph": "^3.0.9",
+        "@tiptap/extension-strike": "^3.0.9",
+        "@tiptap/extension-text": "^3.0.9",
+        "@tiptap/extension-underline": "^3.0.9",
+        "@tiptap/extensions": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       },
       "funding": {
         "type": "github",
@@ -3466,17 +3466,17 @@
       }
     },
     "node_modules/@tiptap/suggestion": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmmirror.com/@tiptap/suggestion/-/suggestion-3.0.7.tgz",
-      "integrity": "sha512-HSMvzAejdvcnVaRZOhXJWAvQqaQs3UYDZaA0ZnzgiJ/sNSbtTyn9XVbX6MfVNYrbtBua4iKaXuJwp6CP0KdHQg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@tiptap/suggestion/-/suggestion-3.0.9.tgz",
+      "integrity": "sha512-irthqfUybezo3IwR6AXvyyTOtkzwfvvst58VXZtTnR1nN6NEcrs3TQoY3bGKGbN83bdiquKh6aU2nLnZfAhoXg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.7",
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -3531,13 +3531,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmmirror.com/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmmirror.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/better-sqlite3": {
@@ -3760,9 +3760,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.16.5",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.16.5.tgz",
-      "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+      "version": "22.17.0",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.17.0.tgz",
+      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5378,9 +5378,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {
@@ -6738,9 +6738,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.191",
-      "resolved": "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
-      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
+      "version": "1.5.194",
+      "resolved": "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
+      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7230,9 +7230,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-9.31.0.tgz",
-      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-9.32.0.tgz",
+      "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7242,8 +7242,8 @@
         "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.31.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/js": "9.32.0",
+        "@eslint/plugin-kit": "^0.3.4",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -7786,21 +7786,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmmirror.com/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -7949,9 +7934,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -9695,35 +9680,21 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmmirror.com/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmmirror.com/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
+        "async": "^3.2.6",
         "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "jake": "bin/cli.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jiti": {
@@ -9851,9 +9822,9 @@
       }
     },
     "node_modules/jsondiffpatch/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-5.5.0.tgz",
+      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -9995,9 +9966,9 @@
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmmirror.com/linkifyjs/-/linkifyjs-4.3.1.tgz",
-      "integrity": "sha512-DRSlB9DKVW04c4SUdGvKK5FR6be45lTU9M76JnngqPeeGDqPwYc0zdUErtsNVMtxPXgUWV4HbXbnC4sNyBxkYg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmmirror.com/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "license": "MIT"
     },
     "node_modules/listr": {
@@ -12298,9 +12269,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmmirror.com/openai/-/openai-5.10.2.tgz",
-      "integrity": "sha512-n+vi74LzHtvlKcDPn9aApgELGiu5CwhaLG40zxLTlFQdoSJCLACORIPC2uVQ3JEYAbqapM+XyRKFy2Thej7bIw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmmirror.com/openai/-/openai-5.11.0.tgz",
+      "integrity": "sha512-+AuTc5pVjlnTuA9zvn8rA/k+1RluPIx9AD4eDcnutv6JNwHHZxIhkFy+tmMKCvmMFDQzfA/r1ujvPWB19DQkYg==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -13365,20 +13336,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-draggable": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmmirror.com/react-draggable/-/react-draggable-4.5.0.tgz",
-      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    },
     "node_modules/react-icons": {
       "version": "5.5.0",
       "resolved": "https://registry.npmmirror.com/react-icons/-/react-icons-5.5.0.tgz",
@@ -13455,6 +13412,20 @@
       },
       "peerDependencies": {
         "react": ">= 16.3"
+      }
+    },
+    "node_modules/react-resizable/node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmmirror.com/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-window": {
@@ -13543,9 +13514,9 @@
       }
     },
     "node_modules/recma-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/recma-jsx/-/recma-jsx-1.0.0.tgz",
-      "integrity": "sha512-5vwkv65qWwYxg+Atz95acp8DMu1JDSqdGkA2Of1j6rCreyFUE/gp15fC8MnGEuG1W68UKjM6x6+YTWIh7hZM/Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
       "license": "MIT",
       "dependencies": {
         "acorn-jsx": "^5.0.0",
@@ -13557,6 +13528,9 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/recma-parse": {
@@ -13954,9 +13928,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.45.1.tgz",
-      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.46.2.tgz",
+      "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13970,26 +13944,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.1",
-        "@rollup/rollup-android-arm64": "4.45.1",
-        "@rollup/rollup-darwin-arm64": "4.45.1",
-        "@rollup/rollup-darwin-x64": "4.45.1",
-        "@rollup/rollup-freebsd-arm64": "4.45.1",
-        "@rollup/rollup-freebsd-x64": "4.45.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-        "@rollup/rollup-linux-arm64-musl": "4.45.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-musl": "4.45.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "@rollup/rollup-android-arm-eabi": "4.46.2",
+        "@rollup/rollup-android-arm64": "4.46.2",
+        "@rollup/rollup-darwin-arm64": "4.46.2",
+        "@rollup/rollup-darwin-x64": "4.46.2",
+        "@rollup/rollup-freebsd-arm64": "4.46.2",
+        "@rollup/rollup-freebsd-x64": "4.46.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.46.2",
+        "@rollup/rollup-linux-arm64-musl": "4.46.2",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.46.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-musl": "4.46.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.46.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.46.2",
+        "@rollup/rollup-win32-x64-msvc": "4.46.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -15542,6 +15516,21 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
@@ -16197,9 +16186,9 @@
       }
     },
     "node_modules/vfile-message": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -16281,6 +16270,21 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
           "optional": true
         }
       }
@@ -16727,9 +16731,9 @@
       "license": "0BSD"
     },
     "node_modules/zustand": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-5.0.6.tgz",
-      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@klarr-agency/circum-icons-react": "^2.0.2",
-        "@lancedb/lancedb": "^0.21.1",
         "@tiptap/core": "^3.0.7",
         "@tiptap/extension-bubble-menu": "^3.0.7",
         "@tiptap/extension-character-count": "^3.0.7",
@@ -2109,168 +2108,6 @@
       "integrity": "sha512-J0gQxEWfpjGrsC3cH84wSgS3iebrXxEjuBMuNdzi8VnPR7ZvBgkmFHLxQwZws1DJ2SjEWnxTyv5RKXtKb74p7Q==",
       "peerDependencies": {
         "react": "^18.1.0"
-      }
-    },
-    "node_modules/@lancedb/lancedb": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb/-/lancedb-0.21.2.tgz",
-      "integrity": "sha512-3RPsGbdhFbwgy7GisQnlgf+5r6R73N4xIkPNISJfvratJ5kVoQIuswra/jJxAf8N5tKriD9UnrQyUsRbmblwFQ==",
-      "cpu": [
-        "x64",
-        "arm64"
-      ],
-      "license": "Apache 2.0",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "reflect-metadata": "^0.2.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "optionalDependencies": {
-        "@lancedb/lancedb-darwin-arm64": "0.21.2",
-        "@lancedb/lancedb-darwin-x64": "0.21.2",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.21.2",
-        "@lancedb/lancedb-linux-arm64-musl": "0.21.2",
-        "@lancedb/lancedb-linux-x64-gnu": "0.21.2",
-        "@lancedb/lancedb-linux-x64-musl": "0.21.2",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.21.2",
-        "@lancedb/lancedb-win32-x64-msvc": "0.21.2"
-      },
-      "peerDependencies": {
-        "apache-arrow": ">=15.0.0 <=18.1.0"
-      }
-    },
-    "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.21.2.tgz",
-      "integrity": "sha512-aCRc/Jrpll7AMQejK18HzNmYtEzV+oU0zTSFhYJTu1SqDTA+CoXoibj9SmXHYwY6MYlfx5y6kI8UkjtU3T8zHQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-darwin-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.21.2.tgz",
-      "integrity": "sha512-Oiiz1W9E2VwKpmPCrRF+40Hd6M1kj/ej6FNQwXaCy688+CJC0dKlz95omQU3B2WnynDiwszUyNVknyMwNI3sCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.21.2.tgz",
-      "integrity": "sha512-LyLlEYUDlpm2sSMzoqmVWIYbY6U5AVZhpZucX0L6a3usyuce6V/Z9UGR6Uw9284xZKsPFnYNRlLZwwUGkb2tKw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-linux-arm64-musl": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.21.2.tgz",
-      "integrity": "sha512-J7fK1gzBrrBx+CnUk+BnvU3V/A+F7EfqveOw2SUbTP7Gy5bXdUL2sieVVuJlRmmhfvjLTAGxsITr2RkO9n3wZw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-linux-x64-gnu": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.21.2.tgz",
-      "integrity": "sha512-yD1lWUe/gLR4QFA3ZdWc2ukdgbfXDcRoi9iTgqedUwAj++Wld64wOFjYhZbYwzGNClXlkJJiP70jzhomBv3RIw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-linux-x64-musl": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.21.2.tgz",
-      "integrity": "sha512-Dq3G6KtGlxidS3mY4cebp7GHRT7rQoe6wpXTzlCankANvEOwxBI68wxid3+GDcqi4jkGHrOrHTQVZqIKZ2NXnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.21.2.tgz",
-      "integrity": "sha512-cPxzm5G2LhiA+DjVGueEnc7K909gzH6q+UGeNXF5Ly4IsvE6BRrjSQNmTRBGflD/aQEV7VD4SqiIj/rpmIZ4Sg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@lancedb/lancedb-win32-x64-msvc": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmmirror.com/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.21.2.tgz",
-      "integrity": "sha512-jewJB5ggDi4jlZocmmjMnwQYDHHr+t0jhiZQINRs/I4tkt9RxaRVPPz7D4rP+NXILj4PgKfDqKcDVeJ/5bc4hQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache 2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -7784,6 +7621,21 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-blob": {
@@ -13336,6 +13188,20 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmmirror.com/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.5.0",
       "resolved": "https://registry.npmmirror.com/react-icons/-/react-icons-5.5.0.tgz",
@@ -13412,20 +13278,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.3"
-      }
-    },
-    "node_modules/react-resizable/node_modules/react-draggable": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmmirror.com/react-draggable/-/react-draggable-4.5.0.tgz",
-      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-window": {
@@ -13564,12 +13416,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmmirror.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -15516,21 +15362,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
@@ -15789,9 +15620,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16270,21 +16101,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "note-by",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "An Note application built with React, TypeScript, and Electron",
   "main": "./out/main/index.js",
   "author": "https://github.com/funkpopo",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@klarr-agency/circum-icons-react": "^2.0.2",
-    "@lancedb/lancedb": "^0.21.1",
     "@tiptap/core": "^3.0.7",
     "@tiptap/extension-bubble-menu": "^3.0.7",
     "@tiptap/extension-character-count": "^3.0.7",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,6 +3,7 @@
   "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
   "compilerOptions": {
     "composite": true,
+    "esModuleInterop": true,
     "types": ["electron-vite/node"]
   }
 }

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -15,6 +15,7 @@
         "src/renderer/src/*"
       ]
     },
+    "module": "esnext",
     "moduleResolution": "bundler"
   }
 }


### PR DESCRIPTION
- 更新至0.1.4
- 移除不再使用的依赖
- 强制兼容tiptap-markdown和tiptap-v3